### PR TITLE
IBX-2317: Added browser tests for tagged releases

### DIFF
--- a/.github/workflows/browser-tests-v3.yaml
+++ b/.github/workflows/browser-tests-v3.yaml
@@ -1,0 +1,67 @@
+name: Browser tests
+
+on:
+    push:
+        tags:
+            - 'v3*'
+
+jobs:
+    regression-commerce-setup1:
+        name: "PHP 7.4/PostgreSQL/Varnish/Redis/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "commerce"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=commerce"
+            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            timeout: 120
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-commerce-setup2:
+        name: "PHP 7.3/MySQL/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "commerce"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=commerce"
+            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            php-image: "ezsystems/php:7.3-v2-node14"
+            timeout: 120
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-commerce-setup3:
+        name: "PHP 8.1/MySQL/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "commerce"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=commerce"
+            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            php-image: "ezsystems/php:8.1-v2-node16"
+            timeout: 120
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/browser-tests-v4.yaml
+++ b/.github/workflows/browser-tests-v4.yaml
@@ -1,0 +1,48 @@
+name: Browser tests
+
+on:
+    push:
+        tags:
+            - 'v4*'
+
+jobs:
+    regression-commerce-setup1:
+        name: "PHP 7.4/Node 14/PostgreSQL/Varnish/Redis/Multirepository"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "commerce"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=commerce"
+            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            multirepository: true
+            timeout: 120
+            php-image: "ezsystems/php:7.4-v2-node14"
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    regression-commerce-setup2:
+        name: "PHP 8.1/Node 16/MySQL/Compatibility layer"
+        uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
+        with:
+            project-edition: "commerce"
+            project-version: ${{ github.ref_name }}
+            test-suite: "--profile=regression --suite=commerce"
+            test-setup-phase-1: "--profile=regression --suite=setup-commerce --tags=~@part2 --mode=standard"
+            test-setup-phase-2: "--profile=regression --suite=setup-commerce --tags=@part2 --mode=standard"
+            setup: "doc/docker/base-dev.yml:doc/docker/selenium.yml"
+            send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
+            job-count: 3
+            use-compatibility-layer: true
+            timeout: 120
+            php-image: "ezsystems/php:8.1-v2-node16"
+        secrets:
+            SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
+            SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
+            TRAVIS_GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-2317


These are similar changes to those introduced in https://github.com/ibexa/oss-skeleton/pull/1
The jobs are taken from:
https://github.com/ibexa/commerce/blob/3.3/.github/workflows/browser-tests.yml (for v3)
https://github.com/ibexa/commerce/blob/master/.github/workflows/browser-tests.yml (for v4)
(with ${{ github.ref_name }} used for project-version everywhere)
but we can discuss whether we should reduce (or expand) the jobs run for tagged releases.

